### PR TITLE
#55: LoginCheckInterceptor 향상

### DIFF
--- a/src/main/java/org/platanus/webboard/auth/LoginCheckConfig.java
+++ b/src/main/java/org/platanus/webboard/auth/LoginCheckConfig.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 @Configuration
 public class LoginCheckConfig implements WebMvcConfigurer {
-
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginCheckInterceptor())
@@ -22,9 +21,6 @@ public class LoginCheckConfig implements WebMvcConfigurer {
                         "/css/**", "/*.ico", "/error",
                         "/session_error",
                         "/api/**");
-//        registry.addInterceptor(new LoginUserInfoInterceptor())
-//                .order(2)
-//                .addPathPatterns("/**");
     }
 
     @Override

--- a/src/main/java/org/platanus/webboard/auth/LoginCheckConfig.java
+++ b/src/main/java/org/platanus/webboard/auth/LoginCheckConfig.java
@@ -1,6 +1,6 @@
 package org.platanus.webboard.auth;
 
-import org.platanus.webboard.web.login.argumentresolver.LoginUserArgumentResolver;
+import org.platanus.webboard.web.login.argumentresolver.LoginArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -9,7 +9,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import java.util.List;
 
 @Configuration
-public class AuthConfig implements WebMvcConfigurer {
+public class LoginCheckConfig implements WebMvcConfigurer {
+
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginCheckInterceptor())
@@ -19,11 +20,15 @@ public class AuthConfig implements WebMvcConfigurer {
                         "/board/*", "/board", "/article/*",
                         "/user/join", "/login", "/logout",
                         "/css/**", "/*.ico", "/error",
+                        "/session_error",
                         "/api/**");
+//        registry.addInterceptor(new LoginUserInfoInterceptor())
+//                .order(2)
+//                .addPathPatterns("/**");
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginUserArgumentResolver());
+        resolvers.add(new LoginArgumentResolver());
     }
 }

--- a/src/main/java/org/platanus/webboard/auth/LoginCheckInterceptor.java
+++ b/src/main/java/org/platanus/webboard/auth/LoginCheckInterceptor.java
@@ -1,6 +1,5 @@
 package org.platanus.webboard.auth;
 
-import lombok.extern.slf4j.Slf4j;
 import org.platanus.webboard.auth.utils.SessionConst;
 import org.platanus.webboard.web.login.dto.UserSessionDto;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -9,33 +8,16 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-@Slf4j
 public class LoginCheckInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request,
                              HttpServletResponse response,
                              Object handler) throws Exception {
         String requestURI = request.getRequestURI();
-        String requestUserAgent = request.getHeader("user-agent");
-        String requestIp = request.getRemoteAddr();
         HttpSession session = request.getSession();
         UserSessionDto userSessionDto = (UserSessionDto) session.getAttribute(SessionConst.LOGIN_USER);
         if (session == null || userSessionDto == null) {
             response.sendRedirect("/login?redirectURL=" + requestURI);
-            return false;
-        }
-        if (!userSessionDto.getUserIp().equals(requestIp)) {
-            log.info("Interceptor detected by session IP non-equal : #{} {}",
-                    userSessionDto.getId(), userSessionDto.getUsername());
-            session.invalidate();
-            response.sendRedirect("/session_error");
-            return false;
-        }
-        if (!userSessionDto.getUserAgent().equals(requestUserAgent)) {
-            log.info("Interceptor detected by session User-Agent non-equal : #{} {}",
-                    userSessionDto.getId(), userSessionDto.getUsername());
-            session.invalidate();
-            response.sendRedirect("/session_error");
             return false;
         }
         return true;

--- a/src/main/java/org/platanus/webboard/auth/LoginUserInfoInterceptor.java
+++ b/src/main/java/org/platanus/webboard/auth/LoginUserInfoInterceptor.java
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 @Slf4j
-public class LoginCheckInterceptor implements HandlerInterceptor {
+public class LoginUserInfoInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request,
                              HttpServletResponse response,
@@ -20,24 +20,10 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
         String requestIp = request.getRemoteAddr();
         HttpSession session = request.getSession();
         UserSessionDto userSessionDto = (UserSessionDto) session.getAttribute(SessionConst.LOGIN_USER);
-        if (session == null || userSessionDto == null) {
-            response.sendRedirect("/login?redirectURL=" + requestURI);
+        if (session == null || userSessionDto == null)
             return false;
-        }
-        if (!userSessionDto.getUserIp().equals(requestIp)) {
-            log.info("Interceptor detected by session IP non-equal : #{} {}",
-                    userSessionDto.getId(), userSessionDto.getUsername());
-            session.invalidate();
-            response.sendRedirect("/session_error");
-            return false;
-        }
-        if (!userSessionDto.getUserAgent().equals(requestUserAgent)) {
-            log.info("Interceptor detected by session User-Agent non-equal : #{} {}",
-                    userSessionDto.getId(), userSessionDto.getUsername());
-            session.invalidate();
-            response.sendRedirect("/session_error");
-            return false;
-        }
+//        request.setAttribute("user",
+//                userSessionDto.from(userService.findById(userSessionDto.getId()), requestUserAgent, requestIp));
         return true;
     }
 }

--- a/src/main/java/org/platanus/webboard/auth/SessionCheckConfig.java
+++ b/src/main/java/org/platanus/webboard/auth/SessionCheckConfig.java
@@ -1,0 +1,15 @@
+package org.platanus.webboard.auth;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class SessionCheckConfig implements WebMvcConfigurer {
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new SessionCheckInterceptor())
+                .order(2)
+                .addPathPatterns("/**");
+    }
+}

--- a/src/main/java/org/platanus/webboard/auth/SessionCheckInterceptor.java
+++ b/src/main/java/org/platanus/webboard/auth/SessionCheckInterceptor.java
@@ -1,0 +1,40 @@
+package org.platanus.webboard.auth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.platanus.webboard.auth.utils.SessionConst;
+import org.platanus.webboard.web.login.dto.UserSessionDto;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@Slf4j
+public class SessionCheckInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws Exception {
+        String requestUserAgent = request.getHeader("user-agent");
+        String requestIp = request.getRemoteAddr();
+        HttpSession session = request.getSession();
+        UserSessionDto userSessionDto = (UserSessionDto) session.getAttribute(SessionConst.LOGIN_USER);
+        if (session != null && userSessionDto != null) {
+            if (!userSessionDto.getUserIp().equals(requestIp)) {
+                log.info("Interceptor detected by session IP non-equal : #{} {}",
+                        userSessionDto.getId(), userSessionDto.getUsername());
+                session.invalidate();
+                response.sendRedirect("/session_error");
+                return false;
+            }
+            if (!userSessionDto.getUserAgent().equals(requestUserAgent)) {
+                log.info("Interceptor detected by session User-Agent non-equal : #{} {}",
+                        userSessionDto.getId(), userSessionDto.getUsername());
+                session.invalidate();
+                response.sendRedirect("/session_error");
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/platanus/webboard/domain/User.java
+++ b/src/main/java/org/platanus/webboard/domain/User.java
@@ -1,6 +1,7 @@
 package org.platanus.webboard.domain;
 
 import lombok.Data;
+import org.platanus.webboard.web.login.dto.UserSessionDto;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -22,4 +23,13 @@ public class User {
     @Email
     private String email;
     private boolean deleted;
+
+    public static User fromLoginSessionDto(UserSessionDto userSessionDto) {
+        User user = new User();
+        user.setId(userSessionDto.getId());
+        user.setUsername(userSessionDto.getUsername());
+        user.setNickname(userSessionDto.getNickname());
+        user.setEmail(userSessionDto.getEmail());
+        return user;
+    }
 }

--- a/src/main/java/org/platanus/webboard/web/board/ArticleWebController.java
+++ b/src/main/java/org/platanus/webboard/web/board/ArticleWebController.java
@@ -34,7 +34,6 @@ public class ArticleWebController {
 
     @GetMapping(value = "/{articleId}")
     public String view(@PathVariable("articleId") long articleId,
-                       @Login UserSessionDto user,
                        Model model) throws Exception {
         Article article = articleService.findById(articleId);
         article.setContent(MarkdownParser.from(article.getContent()));
@@ -51,7 +50,6 @@ public class ArticleWebController {
         String boardName = boardService.findById(article.getBoardId()).getName();
         String boardId = String.valueOf(article.getBoardId());
         CommentWriteDto commentWriteDto = new CommentWriteDto();
-        model.addAttribute("user", user);
         model.addAttribute("board_id", boardId);
         model.addAttribute("article_id", articleId);
         model.addAttribute("board_name", boardName);

--- a/src/main/java/org/platanus/webboard/web/board/BoardListInterceptor.java
+++ b/src/main/java/org/platanus/webboard/web/board/BoardListInterceptor.java
@@ -11,7 +11,9 @@ public class BoardListInterceptor implements HandlerInterceptor {
     private final BoardService boardService;
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws Exception {
         request.setAttribute("boardList", boardService.findAll());
         return true;
     }

--- a/src/main/java/org/platanus/webboard/web/board/BoardWebController.java
+++ b/src/main/java/org/platanus/webboard/web/board/BoardWebController.java
@@ -29,11 +29,9 @@ public class BoardWebController {
     @GetMapping(value = "/{id}")
     public String list(@PathVariable("id") long boardId,
                        @RequestParam(value = "page", defaultValue = "1", required = false) int pageNum,
-                       @Login UserSessionDto user,
                        Model model) throws Exception {
         Page<ArticleListDto> articles = articleService.findPageOfArticlesByBoardId(boardId, pageNum - 1);
         String boardName = boardService.findById(boardId).getName();
-        model.addAttribute("user", user);
         model.addAttribute("articles", articles);
         model.addAttribute("board_id", boardId);
         model.addAttribute("board_name", boardName);
@@ -45,7 +43,6 @@ public class BoardWebController {
                             @Login UserSessionDto user,
                             Model model) throws Exception {
         String boardName = boardService.findById(id).getName();
-        model.addAttribute("user", user);
         model.addAttribute("board_id", id);
         model.addAttribute("board_name", boardName);
         model.addAttribute("article", new ArticleWriteDto());

--- a/src/main/java/org/platanus/webboard/web/board/BoardWebController.java
+++ b/src/main/java/org/platanus/webboard/web/board/BoardWebController.java
@@ -3,10 +3,10 @@ package org.platanus.webboard.web.board;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.platanus.webboard.domain.Article;
-import org.platanus.webboard.domain.User;
 import org.platanus.webboard.web.board.dto.ArticleListDto;
 import org.platanus.webboard.web.board.dto.ArticleWriteDto;
 import org.platanus.webboard.web.login.argumentresolver.Login;
+import org.platanus.webboard.web.login.dto.UserSessionDto;
 import org.platanus.webboard.web.user.UserService;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
@@ -29,7 +29,7 @@ public class BoardWebController {
     @GetMapping(value = "/{id}")
     public String list(@PathVariable("id") long boardId,
                        @RequestParam(value = "page", defaultValue = "1", required = false) int pageNum,
-                       @Login User user,
+                       @Login UserSessionDto user,
                        Model model) throws Exception {
         Page<ArticleListDto> articles = articleService.findPageOfArticlesByBoardId(boardId, pageNum - 1);
         String boardName = boardService.findById(boardId).getName();
@@ -41,8 +41,11 @@ public class BoardWebController {
     }
 
     @GetMapping(value = "/{id}/write")
-    public String writeForm(@PathVariable("id") long id, Model model) throws Exception {
+    public String writeForm(@PathVariable("id") long id,
+                            @Login UserSessionDto user,
+                            Model model) throws Exception {
         String boardName = boardService.findById(id).getName();
+        model.addAttribute("user", user);
         model.addAttribute("board_id", id);
         model.addAttribute("board_name", boardName);
         model.addAttribute("article", new ArticleWriteDto());
@@ -53,7 +56,7 @@ public class BoardWebController {
     public String write(@PathVariable("id") long id,
                         @Valid @ModelAttribute("article") ArticleWriteDto articleRequest,
                         BindingResult bindingResult,
-                        @Login User user) {
+                        @Login UserSessionDto user) {
 
         if (bindingResult.hasErrors()) {
             log.info("Board write #{} by User #{} : {}", id, user.getId(), bindingResult);

--- a/src/main/java/org/platanus/webboard/web/board/CommentWebController.java
+++ b/src/main/java/org/platanus/webboard/web/board/CommentWebController.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.platanus.webboard.domain.Comment;
 import org.platanus.webboard.domain.User;
 import org.platanus.webboard.web.login.argumentresolver.Login;
+import org.platanus.webboard.web.login.dto.UserSessionDto;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,10 +19,12 @@ public class CommentWebController {
     private final CommentService commentService;
 
     @GetMapping(value = "/{commentId}/delete")
-    public String remove(@PathVariable("commentId") long commentId, @Login User user) throws Exception {
+    public String remove(@PathVariable("commentId") long commentId,
+                         @Login UserSessionDto user) throws Exception {
         Comment comment = commentService.findById(commentId);
         long redirectArticleId = comment.getArticleId();
-        if (!commentService.updateDeleteFlag(comment, user)) {
+        User userFromDto = User.fromLoginSessionDto(user);
+        if (!commentService.updateDeleteFlag(comment, userFromDto)) {
             log.info("Comment Controller deleteflag #{} by User #{}", comment.getId(), user.getId());
         }
         log.info("Comment Controller deleteflag #{} by User #{}", comment.getId(), user.getId());

--- a/src/main/java/org/platanus/webboard/web/login/LoginWebController.java
+++ b/src/main/java/org/platanus/webboard/web/login/LoginWebController.java
@@ -4,7 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.platanus.webboard.auth.utils.SessionConst;
 import org.platanus.webboard.domain.User;
-import org.platanus.webboard.web.login.dto.LoginUserDto;
+import org.platanus.webboard.web.login.dto.UserLoginDto;
+import org.platanus.webboard.web.login.dto.UserSessionDto;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,32 +24,33 @@ public class LoginWebController {
     private final LoginService loginService;
 
     @GetMapping("/login")
-    public String loginForm(@ModelAttribute("login") LoginUserDto login) {
+    public String loginForm(@ModelAttribute("login") UserLoginDto login) {
         return "login/login_form";
     }
 
     @PostMapping("/login")
-    public String login(@Valid @ModelAttribute("login") LoginUserDto login,
+    public String login(@Valid @ModelAttribute("login") UserLoginDto userLoginDto,
                         BindingResult bindingResult,
                         @RequestParam(defaultValue = "/") String redirectURL,
                         HttpServletRequest request) {
         User loginUser;
-
         if (bindingResult.hasErrors()) {
             log.error("error = {}", bindingResult);
             return "login/login_form";
         }
-
         try {
-            loginUser = loginService.login(login.getUsername(), login.getPassword());
-            log.info("Login Controller: Login {}", login.getUsername());
+            loginUser = loginService.login(userLoginDto.getUsername(), userLoginDto.getPassword());
+            log.info("Login Controller: Login {}", userLoginDto.getUsername());
         } catch (Exception e) {
             bindingResult.reject("loginFailed", "로그인에 실패 했습니다.");
-            log.info("Login Controller: Login failed {} - {}", login.getUsername(), e.getMessage());
+            log.info("Login Controller: Login failed {} - {}", userLoginDto.getUsername(), e.getMessage());
             return "login/login_form";
         }
+        UserSessionDto userSessionDto = UserSessionDto.from(loginUser,
+                request.getHeader("user-agent"), request.getRemoteAddr());
+        System.out.println(userSessionDto);
         HttpSession session = request.getSession(true);
-        session.setAttribute(SessionConst.LOGIN_USER, loginUser);
+        session.setAttribute(SessionConst.LOGIN_USER, userSessionDto);
         return "redirect:" + redirectURL;
     }
 
@@ -59,5 +61,14 @@ public class LoginWebController {
             session.invalidate();
         }
         return "redirect:/";
+    }
+
+    @GetMapping("/session_error")
+    public String sessionError(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+        return "error/has_session_error";
     }
 }

--- a/src/main/java/org/platanus/webboard/web/login/LoginWebController.java
+++ b/src/main/java/org/platanus/webboard/web/login/LoginWebController.java
@@ -48,7 +48,6 @@ public class LoginWebController {
         }
         UserSessionDto userSessionDto = UserSessionDto.from(loginUser,
                 request.getHeader("user-agent"), request.getRemoteAddr());
-        System.out.println(userSessionDto);
         HttpSession session = request.getSession(true);
         session.setAttribute(SessionConst.LOGIN_USER, userSessionDto);
         return "redirect:" + redirectURL;

--- a/src/main/java/org/platanus/webboard/web/login/argumentresolver/LoginArgumentResolver.java
+++ b/src/main/java/org/platanus/webboard/web/login/argumentresolver/LoginArgumentResolver.java
@@ -1,7 +1,8 @@
 package org.platanus.webboard.web.login.argumentresolver;
 
+import lombok.extern.slf4j.Slf4j;
 import org.platanus.webboard.auth.utils.SessionConst;
-import org.platanus.webboard.domain.User;
+import org.platanus.webboard.web.login.dto.UserSessionDto;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -11,16 +12,20 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+@Slf4j
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
-        boolean hasUserType = User.class.isAssignableFrom(parameter.getParameterType());
+        boolean hasUserType = UserSessionDto.class.isAssignableFrom(parameter.getParameterType());
         return hasLoginAnnotation && hasUserType;
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         HttpSession session = request.getSession(false);
         if (session == null)

--- a/src/main/java/org/platanus/webboard/web/login/dto/UserLoginDto.java
+++ b/src/main/java/org/platanus/webboard/web/login/dto/UserLoginDto.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import javax.validation.constraints.NotBlank;
 
 @Data
-public class LoginUserDto {
+public class UserLoginDto {
     @NotBlank
     private String username;
     private String nickname;

--- a/src/main/java/org/platanus/webboard/web/login/dto/UserSessionDto.java
+++ b/src/main/java/org/platanus/webboard/web/login/dto/UserSessionDto.java
@@ -1,0 +1,24 @@
+package org.platanus.webboard.web.login.dto;
+
+import lombok.Data;
+import org.platanus.webboard.domain.User;
+
+@Data
+public class UserSessionDto {
+    private long id;
+    private String username;
+    private String nickname;
+    private String userAgent;
+    private String email;
+    private String userIp;
+
+    public static UserSessionDto from(User user, String userAgent, String userIp) {
+        UserSessionDto loginSessionDto = new UserSessionDto();
+        loginSessionDto.setId(user.getId());
+        loginSessionDto.setUsername(user.getUsername());
+        loginSessionDto.setNickname(user.getNickname());
+        loginSessionDto.setUserAgent(userAgent);
+        loginSessionDto.setUserIp(userIp);
+        return loginSessionDto;
+    }
+}

--- a/src/main/java/org/platanus/webboard/web/user/UserInfoConfig.java
+++ b/src/main/java/org/platanus/webboard/web/user/UserInfoConfig.java
@@ -1,0 +1,19 @@
+package org.platanus.webboard.web.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class UserInfoConfig implements WebMvcConfigurer {
+    private final UserService userService;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new UserInfoInterceptor(userService))
+                .order(20)
+                .addPathPatterns("/**");
+    }
+}

--- a/src/main/java/org/platanus/webboard/web/user/UserInfoInterceptor.java
+++ b/src/main/java/org/platanus/webboard/web/user/UserInfoInterceptor.java
@@ -1,5 +1,6 @@
-package org.platanus.webboard.auth;
+package org.platanus.webboard.web.user;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.platanus.webboard.auth.utils.SessionConst;
 import org.platanus.webboard.web.login.dto.UserSessionDto;
@@ -10,20 +11,21 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 @Slf4j
-public class LoginUserInfoInterceptor implements HandlerInterceptor {
+@RequiredArgsConstructor
+public class UserInfoInterceptor implements HandlerInterceptor {
+    private final UserService userService;
+
     @Override
     public boolean preHandle(HttpServletRequest request,
                              HttpServletResponse response,
                              Object handler) throws Exception {
-        String requestURI = request.getRequestURI();
         String requestUserAgent = request.getHeader("user-agent");
         String requestIp = request.getRemoteAddr();
         HttpSession session = request.getSession();
         UserSessionDto userSessionDto = (UserSessionDto) session.getAttribute(SessionConst.LOGIN_USER);
-        if (session == null || userSessionDto == null)
-            return false;
-//        request.setAttribute("user",
-//                userSessionDto.from(userService.findById(userSessionDto.getId()), requestUserAgent, requestIp));
+        if (session != null && userSessionDto != null)
+            request.setAttribute("user",
+                    userSessionDto.from(userService.findById(userSessionDto.getId()), requestUserAgent, requestIp));
         return true;
     }
 }

--- a/src/main/resources/templates/error/has_session_error.html
+++ b/src/main/resources/templates/error/has_session_error.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+          crossorigin="anonymous">
+    <title>에러 페이지</title>
+</head>
+<body>
+<div class="container">
+    <div class="d-flex justify-content-center">
+        <div class="board_list shadow p-3 mb-5 bg-body rounded">
+            <div><p>잘못된 세션으로 접근하셨습니다.</p></div>
+            <a class="btn btn-primary btn-floating m-1" href="/login">다시 로그인하기</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/org/platanus/webboard/web/login/LoginWebControllerTest.java
+++ b/src/test/java/org/platanus/webboard/web/login/LoginWebControllerTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.platanus.webboard.auth.utils.SessionConst;
 import org.platanus.webboard.domain.User;
-import org.platanus.webboard.web.login.dto.LoginUserDto;
+import org.platanus.webboard.web.login.dto.UserLoginDto;
 import org.platanus.webboard.web.user.UserService;
 import org.springframework.validation.BindingResult;
 
@@ -35,9 +35,9 @@ public class LoginWebControllerTest {
         BindingResult bindingResult = Mockito.mock(BindingResult.class);
         Mockito.when(bindingResult.hasErrors()).thenReturn(false);
 
-        LoginUserDto loginUserDto = new LoginUserDto();
-        loginUserDto.setUsername("test");
-        loginUserDto.setPassword("test11");
+        UserLoginDto userLoginDto = new UserLoginDto();
+        userLoginDto.setUsername("test");
+        userLoginDto.setPassword("test11");
 
         Map<String, Object> mockSessionMap = new HashMap<>();
         HttpSession httpSession = new MockHttpSession(mockSessionMap);
@@ -45,7 +45,7 @@ public class LoginWebControllerTest {
         Mockito.when(httpServletRequest.getSession(true)).thenReturn(httpSession);
 
         LoginWebController loginWebController = new LoginWebController(loginService);
-        String result = loginWebController.login(loginUserDto, bindingResult, "/success", httpServletRequest);
+        String result = loginWebController.login(userLoginDto, bindingResult, "/success", httpServletRequest);
         assertEquals("redirect:/success", result);
         assertEquals(user, mockSessionMap.get(SessionConst.LOGIN_USER));
     }
@@ -65,9 +65,9 @@ public class LoginWebControllerTest {
         BindingResult bindingResult = Mockito.mock(BindingResult.class);
         Mockito.when(bindingResult.hasErrors()).thenReturn(false);
 
-        LoginUserDto loginUserDto = new LoginUserDto();
-        loginUserDto.setUsername("test");
-        loginUserDto.setPassword("test__failed!!!");
+        UserLoginDto userLoginDto = new UserLoginDto();
+        userLoginDto.setUsername("test");
+        userLoginDto.setPassword("test__failed!!!");
 
         Map<String, Object> mockSessionMap = new HashMap<>();
         HttpSession httpSession = new MockHttpSession(mockSessionMap);
@@ -76,7 +76,7 @@ public class LoginWebControllerTest {
 
         LoginWebController loginWebController = new LoginWebController(loginService);
 
-        assertEquals("login/login_form", loginWebController.login(loginUserDto, bindingResult, "/success", httpServletRequest));
+        assertEquals("login/login_form", loginWebController.login(userLoginDto, bindingResult, "/success", httpServletRequest));
         assertEquals(null, mockSessionMap.get(SessionConst.LOGIN_USER));
     }
 


### PR DESCRIPTION
- ArgumentResolver에서 `User` 객체를 주고 받는 것을 `UserSessionDto`를 만들어 불필요한 정보를 제거하고 User-Agenr와 IP정보를 담도록 했습니다.
- `SessionCheckInterceptor`를 만들어 세션의 IP와 User-Agent가 유효한지 검사해 잘못된 접근이라면 세션을 제거하는 기능을 추가했습니다.
- `User`와 `UserSessionDto`간 상호 변환할 수 있도록 했습니다.
- `UserSessionDto`를 model에 내려보내도록 했습니다.

- - -
issue: #55 